### PR TITLE
Add a fqdn to etc/hosts, speeds up sendmail

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -7,5 +7,12 @@ apachectl -f /etc/apache2/apache2.conf
 sleep 3
 tail -f /var/log/apache2/*&
 
+# Add a fqdn as an alias for the first non-127.0.0.1 ipv4 address to
+# /etc/hosts. This prevents sendmail from adding a 60 second delay on
+# startup while it tries to determine its hostname (see
+# http://selliott.org/node/40).
+cp /etc/hosts /etc/hosts.orig
+sed -e '/^127.0.0.1/! s/^\([0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+\)\t/\1\tmyhost.domain /' </etc/hosts.orig > /etc/hosts
+
 # Start our fake smtp server
 python -m smtpd -n -c DebuggingServer localhost:25


### PR DESCRIPTION
Sendmail will wait 60 seconds if its hostname is not a fqdn and it can't
find an alias in /etc/hosts that is a fqdn. This slows down running the
exploit script.

Fix this by changing /etc/hosts in the entrypoint to add myhost.domain
to the first non-127.0.0.1 ipv4 ip line in /etc/hosts.